### PR TITLE
Add initial database schema

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -29,6 +29,7 @@ CREATE TABLE agency (
 
 CREATE TABLE earthquake_event (
     earthquake_event_id BIGINT GENERATE AS IDENTITY PRIMARY KEY,
+    usgs_event_id BIGINT UNIQUE NOT NULL,
     start_time TIMESTAMP NOT NULL,
     description TEXT NOT NULL,
     creation_time TIMESTAMP NOT NULL,


### PR DESCRIPTION
Create initial database `schema.sql` includes all tables and fields in the ERD plan and proposed data types and foreign key restraints.

Can add other restraints later.

Closes #22 .