### PR TITLE
23 seed database using seedsql

### DIFF
--- a/seed.sql
+++ b/seed.sql
@@ -21,7 +21,8 @@ INSERT INTO country (country_name) VALUES
 ('Panama'),
 ('Columbia'),
 ('Peru'),
-('Ecuador')
+('Ecuador'),
+('Tajikistan')
 ;
 
 INSERT INTO agency (agency_id, agency_name) VALUES


### PR DESCRIPTION
This is a simple script to seed some master data into the database, including countries, agencies and magnitude types. The countries I have listed are all ones that exist on tectonic plate edges, meaning they are most prone to earthquakes, however some countries still unexpectedly get earthquakes, so we may need to upsert rows within the pipeline (in `load.py`).

This closes issue #23 
Closes #35 .