### PR TITLE
Add description to query, now included in email subject and contents

### DIFF
--- a/alerts/earthquake_queries.py
+++ b/alerts/earthquake_queries.py
@@ -15,6 +15,7 @@ def fetch_recent_earthquakes(conn: Connection) -> list[EarthquakeEvent]:
             country_id,
             magnitude_value,
             creation_time,
+            description,
             longitude,
             latitude
         FROM public.event
@@ -27,11 +28,16 @@ def fetch_recent_earthquakes(conn: Connection) -> list[EarthquakeEvent]:
         rows = cur.fetchall()
 
     events: list[EarthquakeEvent] = []
-    for event_id, country_id, magnitude_value, creation_time, longitude, latitude in rows:
+    for event_id, country_id, magnitude_value, creation_time, description, longitude, latitude in rows:
 
-        place: str = None
+        place_parts = []
+        if description:
+            place_parts.append(str(description))
         if latitude is not None and longitude is not None:
-            place = f"{float(latitude):.5f}, {float(longitude):.5f}"
+            place_parts.append(
+                f"{float(latitude):.5f}, {float(longitude):.5f}")
+
+        place = " ".join(place_parts) if place_parts else None
 
         events.append(
             EarthquakeEvent(

--- a/alerts/formatting.py
+++ b/alerts/formatting.py
@@ -7,7 +7,8 @@ from classes import EarthquakeEvent
 def format_subject(event: EarthquakeEvent) -> str:
     """Formats the subject of the alert"""
     country = event.country_name or f"country_id={event.country_id}"
-    return f"Earthquake alert: M{event.magnitude:.1f} in {country}"
+    where = f" - {event.place}" if event.place else ""
+    return f"Earthquake alert: M{event.magnitude:.1f} in {country}{where}"[:100]
 
 
 def format_body(event: EarthquakeEvent) -> str:


### PR DESCRIPTION
Updated files to include description in email subject so users can tell where the earthquake was just by looking at the notification, and will also be able to see it within the contents of the email itself.

Tests to follow.

Issue #53 .