### PR TITLE
Add tests for pure alert functions

### DIFF
--- a/alerts/conftest.py
+++ b/alerts/conftest.py
@@ -1,0 +1,88 @@
+"""Testing suite for the alerts functions"""
+import pytest
+
+from classes import Subscriber, EarthquakeEvent
+
+
+@pytest.fixture
+def any_subscriber():
+    return Subscriber(
+        subscriber_id=1,
+        subscriber_name="Alice",
+        subscriber_email="alice@example.com",
+        weekly=False,
+        country_id=None,
+        magnitude_value=None
+    )
+
+
+@pytest.fixture
+def japan_only_subscriber():
+    return Subscriber(
+        subscriber_id=2,
+        subscriber_name="Bob-san",
+        subscriber_email="bob@example.jp",
+        weekly=False,
+        country_id=116,
+        magnitude_value=None
+    )
+
+
+@pytest.fixture
+def mag_only_subscriber():
+    return Subscriber(
+        subscriber_id=3,
+        subscriber_name="Cara",
+        subscriber_email="cara@example.com",
+        weekly=False,
+        country_id=None,
+        magnitude_value=2.0
+    )
+
+
+@pytest.fixture
+def both_constraints_subscriber():
+    return Subscriber(
+        subscriber_id=4,
+        subscriber_name="Dan",
+        subscriber_email="dan@example.com",  # hi dan
+        weekly=False,
+        country_id=116,
+        magnitude_value=3.5
+    )
+
+
+@pytest.fixture
+def event_japan_small():
+    return EarthquakeEvent(
+        earthquake_id=10,
+        country_id=116,
+        magnitude=1.2,
+        occurred_at="2026-02-06T10:00:00Z",
+        place="7 km W of Osaka, JP",
+        country_name=None
+    )
+
+
+@pytest.fixture
+def event_japan_big():
+    return EarthquakeEvent(
+        earthquake_id=11,
+        country_id=116,
+        magnitude=9.1,
+        occurred_at="2011-03-11T05:46:24Z",
+        place="72 km E of Oshika, JP",
+        country_name=None
+    )
+
+
+@pytest.fixture
+def event_other_big():
+    return EarthquakeEvent(
+        earthquake_id=12,
+        country_id=235,
+        magnitude=9.0,
+        occurred_at="2026-02-06T10:02:00Z",
+        place=None,
+        country_name=None
+    )

--- a/alerts/test_alerts.py
+++ b/alerts/test_alerts.py
@@ -1,1 +1,0 @@
-import pytest

--- a/alerts/test_formatting.py
+++ b/alerts/test_formatting.py
@@ -1,0 +1,61 @@
+from classes import EarthquakeEvent
+from formatting import format_subject, format_body
+
+
+def test_format_subject_prefers_country_name():
+    ev = EarthquakeEvent(
+        earthquake_id=1,
+        country_id=81,
+        magnitude=3.21,
+        occurred_at="2026-02-06T00:00:00Z",
+        place="Near Tokyo",
+        country_name="Japan",
+    )
+    subj = format_subject(ev)
+    assert "Japan" in subj
+    assert "country_id=81" not in subj
+    assert "M3.2" in subj
+
+
+def test_format_subject_falls_back_to_country_id():
+    ev = EarthquakeEvent(
+        earthquake_id=1,
+        country_id=81,
+        magnitude=3.21,
+        occurred_at="t",
+        place=None,
+        country_name=None,
+    )
+    subj = format_subject(ev)
+    assert "country_id=81" in subj
+
+
+def test_format_body_includes_location_description_when_present():
+    ev = EarthquakeEvent(
+        earthquake_id=123,
+        country_id=81,
+        magnitude=4.0,
+        occurred_at="2026-02-06T00:00:00Z",
+        place="7 km W of Cobb, CA (38.8220, -122.7250)",
+        country_name="Japan",
+    )
+    body = format_body(ev)
+    assert "Earthquake ID: 123" in body
+    assert "Time: 2026-02-06T00:00:00Z" in body
+    assert "Country: Japan" in body
+    assert "Magnitude: 4.0" in body
+    assert "Location: 7 km W of Cobb, CA" in body
+
+
+def test_format_body_omits_location_line_when_place_missing():
+    ev = EarthquakeEvent(
+        earthquake_id=123,
+        country_id=81,
+        magnitude=4.0,
+        occurred_at="t",
+        place=None,
+        country_name=None,
+    )
+    body = format_body(ev)
+    assert "Location:" not in body
+    assert "Country: (country_id=81)" in body

--- a/alerts/test_preferences.py
+++ b/alerts/test_preferences.py
@@ -1,0 +1,46 @@
+from classes import EarthquakeEvent
+from preferences import matches
+
+
+def test_matches_no_constraints(any_subscriber, event_other_big):
+    assert matches(any_subscriber, event_other_big) is True
+
+
+def test_matches_country_only_success(japan_only_subscriber, event_japan_small):
+    assert matches(japan_only_subscriber, event_japan_small) is True
+
+
+def test_matches_country_only_failure(japan_only_subscriber, event_other_big):
+    assert matches(japan_only_subscriber, event_other_big) is False
+
+
+def test_matches_magnitude_only_success(mag_only_subscriber, event_japan_big):
+    assert matches(mag_only_subscriber, event_japan_big) is True
+
+
+def test_matches_magnitude_only_failure_below_threshold(mag_only_subscriber, event_japan_small):
+    assert matches(mag_only_subscriber, event_japan_small) is False
+
+
+def test_matches_both_success(both_constraints_subscriber, event_japan_big):
+    assert matches(both_constraints_subscriber, event_japan_big) is True
+
+
+def test_matches_both_fails_country(both_constraints_subscriber, event_other_big):
+    assert matches(both_constraints_subscriber, event_other_big) is False
+
+
+def test_matches_both_fails_magnitude(both_constraints_subscriber, event_japan_small):
+    assert matches(both_constraints_subscriber, event_japan_small) is False
+
+
+def test_matches_magnitude_only_inclusive_boundary(mag_only_subscriber):
+    ev = EarthquakeEvent(
+        earthquake_id=99,
+        country_id=1,
+        magnitude=2.0,
+        occurred_at="2026-02-06T00:00:00Z",
+        place=None,
+        country_name=None,
+    )
+    assert matches(mag_only_subscriber, ev) is True

--- a/alerts/test_sns_client_pure.py
+++ b/alerts/test_sns_client_pure.py
@@ -1,0 +1,24 @@
+from sns_client import build_filter_policy
+
+
+def test_build_filter_policy_empty_when_no_constraints():
+    assert build_filter_policy(country_id=None, magnitude_value=None) == {}
+
+
+def test_build_filter_policy_country_only():
+    assert build_filter_policy(country_id=81, magnitude_value=None) == {
+        "country_id": ["81"]
+    }
+
+
+def test_build_filter_policy_magnitude_only():
+    assert build_filter_policy(country_id=None, magnitude_value=2.0) == {
+        "magnitude": [{"numeric": [">=", 2.0]}]
+    }
+
+
+def test_build_filter_policy_both():
+    assert build_filter_policy(country_id=81, magnitude_value=3.5) == {
+        "country_id": ["81"],
+        "magnitude": [{"numeric": [">=", 3.5]}],
+    }


### PR DESCRIPTION
Added 17 tests to test different outputs for pure functions in the alert scripts, will probably parametrise them later and make more use of the fixtures for better organisation and readability.

Will also add tests for impure functions later on.

Closes #107 .