### PR TITLE
117-fix-streamlit-not-displaying-logo-on-cloud

### DIFF
--- a/dashboard/Dashboard.py
+++ b/dashboard/Dashboard.py
@@ -54,7 +54,8 @@ def sidebar_logo(path: str, bg="#121B2F", pad="0", radius="0px"):
     )
 
 
-sidebar_logo("assets/tremorlytics.png")
+logo_path = Path(__file__).resolve().parent / "assets" / "tremorlytics.png"
+sidebar_logo(str(logo_path))
 
 alt.themes.register("tremor", tremor_theme)
 alt.themes.enable("tremor")

--- a/dashboard/pages/2_Subscription.py
+++ b/dashboard/pages/2_Subscription.py
@@ -28,7 +28,8 @@ def sidebar_logo(path: str, bg="#121B2F", pad="0", radius="0px"):
     )
 
 
-sidebar_logo("assets/tremorlytics.png")
+logo_path = Path(__file__).resolve().parents[1] / "assets" / "tremorlytics.png"
+sidebar_logo(str(logo_path))
 
 
 def get_email():


### PR DESCRIPTION
Fixed the sidebar logo not showing on deploy by switching to file relative paths so it works locally and on Streamlit Cloud