### PR TITLE
Fix pip install command in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,11 +22,11 @@ jobs:
             uses: actions/setup-python@v6
           - name: "Install libraries"
             run: pip install -r alerts/requirements.txt \ 
-                  app/requirements.txt \ 
-                  dashboard/requirements.txt \ 
-                  database/requirements.txt \
-                  pipeline/requirements.txt \
-                  weekly_report/requirements.txt
+                  -r app/requirements.txt \ 
+                  -r dashboard/requirements.txt \ 
+                  -r database/requirements.txt \
+                  -r pipeline/requirements.txt \
+                  -r weekly_report/requirements.txt
           - name: "Run tests"
             run: pytest alerts/*.py
     pylinting_alerts:


### PR DESCRIPTION
All files need the -r tag apparently.